### PR TITLE
Refactoring: depend directly on cats effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # unreleased
 
+# 0.4.0
+
+Reverse deprecation warnings. Usage of `pureharm-config` is still discouraged in favor of other modules. But, this release will be the last one which will be used by downstream pureharm modules, leaving it to the user to determine how configs ought to be read.
+
+### dependency changes
+
+- drop dependency on [pureharm-effects-cats](https://github.com/busymachines/pureharm-effects-cats/releases), depend only on [`cats-effect`](https://github.com/typelevel/cats-effect/releases) `2.4.1`
+
 # 0.3.0
 
 Still EOL, small maintenance release.
 
-### Dependency upgrades
+### dependency upgrades
 
 - [pureharm-effects-cats](https://github.com/busymachines/pureharm-effects-cats/releases) `0.4.0`
 
@@ -19,9 +27,6 @@ Still EOL, small maintenance release.
 
 This release marks the end of the line for pureharm-config. From now on, pureharm modules will encourage users to depend on `pureharm-config-ciris`, and they will deprecate the usage of `pureharm-config`, and removing it completely starting versions `0.3.x` onwards.
 
-### Dependency upgrades
-
--
 
 # 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Reverse deprecation warnings. Usage of `pureharm-config` is still discouraged in favor of other modules. But, this release will be the last one which will be used by downstream pureharm modules, leaving it to the user to determine how configs ought to be read.
 
+### breaking changes
+
+- support only `RefinedTypeThrow` instead of the generic `RefinedType` sprout implicits. Part of a larger decision for pureharm to support only `Throwable`-like error channels.
+
 ### dependency changes
 
 - drop dependency on [pureharm-effects-cats](https://github.com/busymachines/pureharm-effects-cats/releases), depend only on [`cats-effect`](https://github.com/typelevel/cats-effect/releases) `2.4.1`
@@ -26,7 +30,6 @@ Still EOL, small maintenance release.
 # 0.2.0
 
 This release marks the end of the line for pureharm-config. From now on, pureharm modules will encourage users to depend on `pureharm-config-ciris`, and they will deprecate the usage of `pureharm-config`, and removing it completely starting versions `0.3.x` onwards.
-
 
 # 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pureharm-config
 
-Version ~~0.2.0~~0.3.0 is end of the line for `pureharm-config` it is being superseded by `pureharm-config-ciris` which dramatically alters the way configs are dealt with. So it's no small change. Starting with versions `0.2.0` downstream pureharm moduls (e.g, db-slick, db-doobie, aws, etc) will deprecate the usage of the `ConfigLoader` companion objects for their configurations and encourage users to use `ciris` to read the configs on user side with the prefered method. Starting with version `0.3.0` no downstream module will be coupled with the concrete method of reading configs anymore, it will all be left in user-land, and recommended to be done w/ `pureharm-config-ciris`.
+Version `0.4.0` is end of the line for `pureharm-config` it is being superseded by `pureharm-config-ciris` which dramatically alters the way configs are dealt with. So it's no small change. Starting with versions `0.3.0` (`0.4.0` in some cases) downstream pureharm modules (e.g, db-slick, db-doobie, aws, etc) will deprecate the usage of the `ConfigLoader` companion objects for their configurations and encourage users to use `ciris` to read the configs on user side with the prefered method.
+
+`pureharm-config` will still be released w/ maintenance releases, but it should be used in user-code, and will no longer be pulled in by future pureharm-modules.
 
 The latter approach has many advantages, including easier publishing of the whole pureharm thing.
 
@@ -10,11 +12,11 @@ See [changelog](./CHANGELOG.md).
 
 The available modules are.
 
-- `"com.busymachines" %% s"pureharm-config" % "0.3.0"`. Which has these as its main dependencies:
+- `"com.busymachines" %% s"pureharm-config" % "0.4.0"`. Which has these as its main dependencies:
+  - [cats-effect](https://github.com/typelevel/cats-effect/releases) `2.4.1`
   - [pureconfig](https://github.com/pureconfig/pureconfig/releases) `0.14.0`
   - [pureharm-core-anomaly](https://github.com/busymachines/pureharm-core/releases) `0.2.0`
   - [pureharm-core-sprout](https://github.com/busymachines/pureharm-core/releases) `0.2.0`
-  - [pureharm-effects-cats](https://github.com/busymachines/pureharm-effects-cats/releases) `0.4.0`
 
 ## usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ addCommandAlias("github-check", "githubWorkflowCheck")
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 val Scala213  = "2.13.5"
-val Scala3RC1 = "3.0.0-RC1"
 
 //=============================================================================
 //============================ publishing details =============================
@@ -32,7 +31,7 @@ val Scala3RC1 = "3.0.0-RC1"
 //see: https://github.com/xerial/sbt-sonatype#buildsbt
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 
-ThisBuild / baseVersion  := "0.3"
+ThisBuild / baseVersion  := "0.4"
 ThisBuild / organization := "com.busymachines"
 ThisBuild / organizationName := "BusyMachines"
 ThisBuild / homepage     := Option(url("https://github.com/busymachines/pureharm-config"))
@@ -75,7 +74,6 @@ ThisBuild / crossScalaVersions := List(Scala213) //List(Scala213, Scala3RC1)
 //required for binary compat checks
 ThisBuild / versionIntroduced := Map(
   Scala213  -> "0.1.0",
-  Scala3RC1 -> "0.1.0",
 )
 
 //=============================================================================
@@ -84,13 +82,13 @@ ThisBuild / versionIntroduced := Map(
 ThisBuild / resolvers += Resolver.sonatypeRepo("releases")
 ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
 
-val pureconfigV      = "0.14.0" //https://github.com/pureconfig/pureconfig/releases
-val pureharmCoreV    = "0.2.0"  //https://github.com/busymachines/pureharm-core/releases
-val pureharmEffectsV = "0.2.0"  //https://github.com/busymachines/pureharm-effects-cats/releases
-
-//for testing
-val pureharmTestkitV = "0.2.0" //https://github.com/busymachines/pureharm-testkit/releases
-val log4catsV = "1.2.2" //https://github.com/typelevel/log4cats/releases
+// format: on
+val pureconfigV       = "0.14.0"    //https://github.com/pureconfig/pureconfig/releases
+val catsEffectV       = "2.4.1"     //https://github.com/typelevel/cats-effect/releases
+val pureharmCoreV     = "0.2.0"     //https://github.com/busymachines/pureharm-core/releases
+val pureharmTestkitV  = "0.3.0"     //https://github.com/busymachines/pureharm-testkit/releases
+val log4catsV         = "1.2.2"     //https://github.com/typelevel/log4cats/releases
+// format: off
 
 //=============================================================================
 //============================== Project details ==============================
@@ -110,12 +108,14 @@ lazy val config = project
   .settings(
     name := "pureharm-config",
     libraryDependencies ++= Seq(
-      "com.github.pureconfig" %% "pureconfig" % pureconfigV withSources(),
-      "com.busymachines" %% "pureharm-core-anomaly" % pureharmCoreV withSources(),
-      "com.busymachines" %% "pureharm-core-sprout" % pureharmCoreV withSources(),
-      "com.busymachines" %% "pureharm-effects-cats" % pureharmEffectsV withSources(),
-      "com.busymachines" %% "pureharm-testkit" % pureharmTestkitV % Test withSources(),
-      "org.typelevel" %% "log4cats-slf4j" % log4catsV % Test withSources(),
+      // format: off
+      "org.typelevel"           %% "cats-effect"              % catsEffectV                 withSources(),
+      "com.github.pureconfig"   %% "pureconfig"               % pureconfigV                 withSources(),
+      "com.busymachines"        %% "pureharm-core-anomaly"    % pureharmCoreV               withSources(),
+      "com.busymachines"        %% "pureharm-core-sprout"     % pureharmCoreV               withSources(),
+      "com.busymachines"        %% "pureharm-testkit"         % pureharmTestkitV  % Test    withSources(),
+      "org.typelevel"           %% "log4cats-noop"            % log4catsV         % Test    withSources(),
+      // format: off
     ),
   ).settings(
     javaOptions ++= Seq("-source", "1.8", "-target", "1.8")
@@ -126,9 +126,6 @@ lazy val config = project
 //=============================================================================
 
 lazy val commonSettings = Seq(
-  //required for munit: https://scalameta.org/munit/docs/getting-started.html
-  testFrameworks += new TestFramework("munit.Framework"),
-
   Compile / unmanagedSourceDirectories ++= {
     val major = if (isDotty.value) "-3" else "-2"
     List(CrossType.Pure, CrossType.Full).flatMap(

--- a/config/src/main/scala/busymachines/pureharm/internals/config/ConfigLoader.scala
+++ b/config/src/main/scala/busymachines/pureharm/internals/config/ConfigLoader.scala
@@ -16,8 +16,8 @@
 
 package busymachines.pureharm.internals.config
 
-import busymachines.pureharm.effects._
-import busymachines.pureharm.effects.implicits._
+import cats.syntax.all._
+import cats.effect._
 import pureconfig._
 import pureconfig.error.ConfigReaderFailures
 
@@ -36,10 +36,6 @@ import pureconfig.error.ConfigReaderFailures
   * @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 20 Jun 2018
   */
-@scala.deprecatedInheritance(
-  "pureharm-config is at the end-of-life. Please use pureharm-config-ciris, or inline this library",
-  "0.3.0",
-)
 trait ConfigLoader[Config] {
 
   /** This exists to force semi-auto-derivation, and it allows us to build

--- a/config/src/main/scala/busymachines/pureharm/internals/config/PureharmConfigInstances.scala
+++ b/config/src/main/scala/busymachines/pureharm/internals/config/PureharmConfigInstances.scala
@@ -16,8 +16,9 @@
 
 package busymachines.pureharm.internals.config
 
-import busymachines.pureharm.effects._
-import busymachines.pureharm.effects.implicits._
+import cats.Show
+import cats.syntax.all._
+
 import busymachines.pureharm.sprout._
 import pureconfig.error.CannotConvert
 import pureconfig.{ConfigReader, ConfigWriter}

--- a/config/src/main/scala/busymachines/pureharm/internals/config/PureharmConfigInstances.scala
+++ b/config/src/main/scala/busymachines/pureharm/internals/config/PureharmConfigInstances.scala
@@ -42,17 +42,20 @@ object PureharmConfigInstances {
       reader:  ConfigWriter[Underlying],
     ): ConfigWriter[New] = reader.contramap(oldType.oldType)
 
-    implicit final def pureharmRefinedTypeConfigReader[Underlying, New, E](implicit
-      refined: RefinedType[Underlying, New, E],
-      reader:  ConfigReader[Underlying],
-      show:    Show[E],
+    implicit final def pureharmRefinedTypeThrowConfigReader[Underlying, New, E](implicit
+      refined: RefinedTypeThrow[Underlying, New],
       ushow:   Show[Underlying],
+      reader:  ConfigReader[Underlying],
     ): ConfigReader[New] =
       reader.emap(s =>
         refined
-          .newType[Either[E, *]](s)
+          .newType[Either[Throwable, *]](s)
           .leftMap(e =>
-            CannotConvert(value = s.show, toType = s"SproutRefined[${s.getClass.getCanonicalName}]", because = e.show)
+            CannotConvert(
+              value   = s.show,
+              toType  = s"SproutRefined[${refined.symbolicName}]",
+              because = e.toString,
+            )
           )
       )
   }

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfig.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfig.scala
@@ -33,11 +33,10 @@ final private[test] case class PureharmTestConfig(
 
 import busymachines.pureharm.config._
 
-@scala.annotation.nowarn
 private[test] object PureharmTestConfig extends ConfigLoader[PureharmTestConfig] {
   implicit val throwableShow: cats.Show[Throwable] = cats.Show.fromToString[Throwable]
   import busymachines.pureharm.config.implicits._ //needed for all sprout implicits
-  import busymachines.pureharm.effects._
+  import cats.effect._
 
   implicit override val configReader: ConfigReader[PureharmTestConfig] =
     semiauto.deriveReader[PureharmTestConfig]

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigFromDefaultSourceTest.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigFromDefaultSourceTest.scala
@@ -29,7 +29,7 @@ import busymachines.pureharm.testkit.TestLogger
   */
 final class PureharmTestConfigFromDefaultSourceTest extends PureharmTest {
 
-  implicit override val testLogger: TestLogger = TestLogger(org.typelevel.log4cats.slf4j.Slf4jLogger.getLogger[IO])
+  implicit override val testLogger: TestLogger = TestLogger(org.typelevel.log4cats.noop.NoOpLogger[IO])
 
   test("load config from correct custom path") {
     val correct = new PureharmTestConfigLoaderFromSource("not-a-conf.txt")
@@ -44,7 +44,7 @@ final class PureharmTestConfigFromDefaultSourceTest extends PureharmTest {
         PhantomSet(Set("value1", "value2")),
         PhantomFiniteDuration(10.minutes),
         PhantomDuration(10.minutes),
-        SafePhantomInt[Attempt](123).unsafeGet(),
+        SafePhantomInt[Try](123).get,
       )
     )
   }

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigLoaderFromSource.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigLoaderFromSource.scala
@@ -23,7 +23,6 @@ import busymachines.pureharm.config._
 import busymachines.pureharm.effects._
 import busymachines.pureharm.effects.implicits._
 
-@scala.annotation.nowarn
 private[test] class PureharmTestConfigLoaderFromSource(filePath: String) extends ConfigLoader[PureharmTestConfig] {
 
   override def configSource[F[_]](implicit F: Sync[F]): F[ConfigSource] =

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigTest.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigTest.scala
@@ -27,7 +27,7 @@ import busymachines.pureharm.testkit._
   */
 final class PureharmTestConfigTest extends PureharmTest {
 
-  implicit override val testLogger: TestLogger = TestLogger(org.typelevel.log4cats.slf4j.Slf4jLogger.getLogger[IO])
+  implicit override val testLogger: TestLogger = TestLogger(org.typelevel.log4cats.noop.NoOpLogger[IO])
 
   test("load config with phantom common types") {
 
@@ -42,7 +42,7 @@ final class PureharmTestConfigTest extends PureharmTest {
         PhantomSet(Set("value1", "value2")),
         PhantomFiniteDuration(10.minutes),
         PhantomDuration(10.minutes),
-        SafePhantomInt[Attempt](123).unsafeGet(),
+        SafePhantomInt[Try](123).get,
       )
     )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 // https://github.com/sbt/sbt/releases
-sbt.version=1.4.9
+sbt.version=1.5.0


### PR DESCRIPTION
- Reverse decision to add deprecation warnings
- support only `RefinedTypeThrow` sprouts